### PR TITLE
Feat/refactor stack display

### DIFF
--- a/multitree-tasks.xcodeproj/project.pbxproj
+++ b/multitree-tasks.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		B25E5DE62C41FDFB00495CC5 /* ColumnsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B25E5DE52C41FDFB00495CC5 /* ColumnsView.swift */; };
 		B25E5DE82C41FE6A00495CC5 /* PagesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B25E5DE72C41FE6A00495CC5 /* PagesView.swift */; };
 		B25E5DEA2C41FEA300495CC5 /* SharedRootViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = B25E5DE92C41FEA300495CC5 /* SharedRootViews.swift */; };
+		B25E5DEE2C42F19500495CC5 /* NodeDisplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = B25E5DED2C42F19500495CC5 /* NodeDisplay.swift */; };
 		B29C852D2C3DC99F00452828 /* Root.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29C852C2C3DC99E00452828 /* Root.swift */; };
 		B2F48EDE2C35951E00D39F29 /* TaskNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2F48EDD2C35951600D39F29 /* TaskNode.swift */; };
 		B2F48EE22C3599F000D39F29 /* TaskNodeBag.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2F48EE12C3599E400D39F29 /* TaskNodeBag.swift */; };
@@ -28,6 +29,7 @@
 		B25E5DE52C41FDFB00495CC5 /* ColumnsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColumnsView.swift; sourceTree = "<group>"; };
 		B25E5DE72C41FE6A00495CC5 /* PagesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagesView.swift; sourceTree = "<group>"; };
 		B25E5DE92C41FEA300495CC5 /* SharedRootViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedRootViews.swift; sourceTree = "<group>"; };
+		B25E5DED2C42F19500495CC5 /* NodeDisplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeDisplay.swift; sourceTree = "<group>"; };
 		B29C852C2C3DC99E00452828 /* Root.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Root.swift; sourceTree = "<group>"; };
 		B2F48EDD2C35951600D39F29 /* TaskNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskNode.swift; sourceTree = "<group>"; };
 		B2F48EE12C3599E400D39F29 /* TaskNodeBag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskNodeBag.swift; sourceTree = "<group>"; };
@@ -70,6 +72,7 @@
 				B2F48EE12C3599E400D39F29 /* TaskNodeBag.swift */,
 				B2F48EDD2C35951600D39F29 /* TaskNode.swift */,
 				B25E5DE32C41782300495CC5 /* Node.swift */,
+				B25E5DED2C42F19500495CC5 /* NodeDisplay.swift */,
 			);
 			path = tca;
 			sourceTree = "<group>";
@@ -187,6 +190,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B25E5DEE2C42F19500495CC5 /* NodeDisplay.swift in Sources */,
 				B2F48EE22C3599F000D39F29 /* TaskNodeBag.swift in Sources */,
 				B2F48EDE2C35951E00D39F29 /* TaskNode.swift in Sources */,
 				B2FB1C162C359220000A04B0 /* RootView.swift in Sources */,

--- a/multitree-tasks/swiftui/ColumnsView.swift
+++ b/multitree-tasks/swiftui/ColumnsView.swift
@@ -33,7 +33,9 @@ struct ColumnsView: View {
                     ForEach(path.ids, id: \.self) { stackID in
                         if let nodeStore = store.scope(state: \.path[id: stackID],
                                                        action: \.path[id: stackID]) {
-                            SharedRootViews.NodeDisplay(store: store, node: nodeStore, style: .columns)
+                            SharedRootViews.NodeDisplayView(store: store,
+                                                            node: nodeStore,
+                                                            style: .columns)
                             Divider()
                         }
                     }

--- a/multitree-tasks/swiftui/PagesView.swift
+++ b/multitree-tasks/swiftui/PagesView.swift
@@ -14,7 +14,7 @@ struct PagesView: View {
         NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
             SharedRootViews.NavigationRoot(store: store)
         } destination: { node in
-            SharedRootViews.NodeDisplay(store: store, node: node, style: .pages)
+            SharedRootViews.NodeDisplayView(store: store, node: node, style: .pages)
                 .toolbar {
                     SharedRootViews.SharedToolbar(store: store)
                 }
@@ -23,7 +23,7 @@ struct PagesView: View {
     }
 
     var title: String {
-        if let lastID = store.path.last, let task = store.bag.tasks[id: lastID] {
+        if let last = store.path.last, let task = store.bag.tasks[id: last.id] {
             return task.detail.title
         }
         return ""

--- a/multitree-tasks/swiftui/RootView.swift
+++ b/multitree-tasks/swiftui/RootView.swift
@@ -23,15 +23,16 @@ struct RootView: View {
         .alert("Create Node", isPresented: $store.addTask) {
             TextField("Node Title", text: $store.workingTaskTitle)
             Button("Create") {
-                store.send(.addTask)
+                store.scope(state: \.path, action: \.path)
+                    .send(.element(id: store.path.ids.last!, action: .addChild))
             }
             .disabled(store.workingTaskTitle.isEmpty)
             Button("Cancel", role: .cancel) {
                 store.send(.set(\.addTask, false))
             }
         } message: {
-            if let last = store.path.last {
-                Text("Add a node to **\(store.bag.tasks[id: last]!.detail.title).**")
+            if let last = store.path.last, let task = store.bag.tasks[id: last] {
+                Text("Add a node to **\(task.detail.title).**")
             } else {
                 Text("Add a node to **Root**.")
             }

--- a/multitree-tasks/swiftui/RootView.swift
+++ b/multitree-tasks/swiftui/RootView.swift
@@ -31,7 +31,7 @@ struct RootView: View {
                 store.send(.set(\.addTask, false))
             }
         } message: {
-            if let last = store.path.last, let task = store.bag.tasks[id: last] {
+            if let last = store.path.last, let task = store.bag.tasks[id: last.id] {
                 Text("Add a node to **\(task.detail.title).**")
             } else {
                 Text("Add a node to **Root**.")

--- a/multitree-tasks/swiftui/SharedRootViews.swift
+++ b/multitree-tasks/swiftui/SharedRootViews.swift
@@ -46,15 +46,15 @@ struct SharedRootViews {
         }
     }
 
-    struct NodeDisplay: View {
+    struct NodeDisplayView: View {
         @Bindable var store: StoreOf<Root>
-        @Bindable var node: StoreOf<Root.StackDisplayFeature>
+        @Bindable var node: StoreOf<NodeDisplay<Root.ID>>
         @State var style: Style
 
         var body: some View {
-            let id = node.state
+            let state = node.state
             let path = store.path
-            let children = store.bag.tasks[id: id]!.childrenIDs
+            let children = store.bag.tasks[id: state.id]!.childrenIDs
             switch children.count {
             case 0:
                 let rotation: Double = switch style {
@@ -66,9 +66,9 @@ struct SharedRootViews {
                     .rotationEffect(.degrees(rotation))
             case let count:
                 VStack {
-                    if let index = path.firstIndex(of: id) {
+                    if let index = path.firstIndex(of: state) {
                         let selected: Set<Root.ID> = (path.count - 1 > index
-                                                      ? .init([path[index + 1]])
+                                                      ? .init([path[index + 1].id])
                                                       : .init())
                         List(children, id: \.self, selection: .constant(selected)) { id in
                             item(id: id)
@@ -129,7 +129,7 @@ struct SharedRootViews {
                 }
                 Button("Search", systemImage: "magnifyingglass") { }
             }
-            if let lastID = store.path.last, let task = store.bag.tasks[id: lastID] {
+            if let last = store.path.last, let task = store.bag.tasks[id: last.id] {
                 ToolbarItem(placement: .bottomBar) {
                     VStack {
                         Divider()

--- a/multitree-tasks/swiftui/SharedRootViews.swift
+++ b/multitree-tasks/swiftui/SharedRootViews.swift
@@ -38,7 +38,7 @@ struct SharedRootViews {
                 ToolbarItem(placement: .primaryAction) {
                     Button("Cross", systemImage: "multiply") {
                         store.send(.set(\.workingTaskTitle, "Generated"))
-                        store.send(.addTask)
+                        store.send(.addTask(.none))
                     }
                 }
             }
@@ -114,22 +114,18 @@ struct SharedRootViews {
 
         var body: some ToolbarContent {
             ToolbarItemGroup(placement: .primaryAction) {
+                let path = store.path
                 Button("Add One", systemImage: "plus") {
                     store.send(.set(\.addTask, true))
                 }
                 Button("Cross", systemImage: "multiply") {
                     store.send(.set(\.workingTaskTitle, "Generated"))
-                    let path = store.path
-                    switch path.count {
-                    case 0:
-                        store.send(.addTask)
-                    default:
+                    if let lastID = path.ids.last {
                         store.scope(state: \.path, action: \.path)
-                            .send(.element(id: path.ids.last!, action: .addChild))
+                            .send(.element(id: lastID, action: .addChild))
                     }
                 }
                 Button("Add Multiple", systemImage: "plus.square.on.square") {
-    //                        store.send(.set(\.addTask, true))
                 }
                 Button("Search", systemImage: "magnifyingglass") { }
             }
@@ -156,4 +152,29 @@ struct SharedRootViews {
             }
         }
     }
+
+//    struct AddTaskFormView: View {
+//        @Bindable var store: StoreOf<AddTaskForm>
+//
+//        var body: some View {
+//            List {
+//                LabeledContent("Title") {
+//                    TextField("Title", text: $store.title)
+//                }
+//            }
+//            .toolbar {
+//                ToolbarItem(placement: .primaryAction) {
+//                    Button("Create", systemImage: "checkmark") {
+//                        store.send(.submitButtonTapped)
+//                    }
+//                }
+//                ToolbarItem(placement: .cancellationAction) {
+//                    Button("Cancel", systemImage: "xmark", role: .cancel) {
+//                        store.send(.dismissButtonTapped)
+//                    }
+//                }
+//            }
+//            .navigationTitle("Node Creation")
+//        }
+//    }
 }

--- a/multitree-tasks/tca/NodeDisplay.swift
+++ b/multitree-tasks/tca/NodeDisplay.swift
@@ -42,7 +42,7 @@ extension NodeDisplay {
     struct AddForm {
         @ObservableState
         struct State: Equatable {
-            let parentID: Root.ID
+            let parentID: ID
             var title: String = ""
             // TODO: add repeat, toggles, or reparenting info here
         }

--- a/multitree-tasks/tca/NodeDisplay.swift
+++ b/multitree-tasks/tca/NodeDisplay.swift
@@ -1,0 +1,72 @@
+//
+//  NodeDisplay.swift
+//  multitree-tasks
+//
+//  Created by hung on 7/13/24.
+//
+
+import ComposableArchitecture
+
+@Reducer
+struct NodeDisplay<ID> where ID: Hashable {
+    @Reducer(state: .equatable)
+    enum Destination {
+        case add(AddForm)
+    }
+
+    @ObservableState
+    struct State: Identifiable, Equatable {
+        let id: ID
+
+        @Presents var destination: Destination.State?
+    }
+
+    enum Action {
+        case addChild
+        case edit
+        case move
+        case selectChild(ID)
+        case destination(PresentationAction<Destination.Action>)
+    }
+
+    var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            return .none
+        }        
+        .ifLet(\.$destination, action: \.destination)
+    }
+}
+
+extension NodeDisplay {
+    @Reducer
+    struct AddForm {
+        @ObservableState
+        struct State: Equatable {
+            let parentID: Root.ID
+            var title: String = ""
+            // TODO: add repeat, toggles, or reparenting info here
+        }
+
+        enum Action: BindableAction {
+            case binding(BindingAction<State>)
+            case dismissButtonTapped
+            case submitButtonTapped
+        }
+
+        @Dependency(\.dismiss) var dismiss
+        var body: some ReducerOf<Self> {
+            BindingReducer()
+            Reduce { state, action in
+                switch action {
+                case .dismissButtonTapped:
+                    return .run { _ in
+                        await dismiss()
+                    }
+                case .submitButtonTapped: // let parent handle submission
+                    return .none
+                case .binding: return .none
+                }
+            }
+        }
+    }
+}

--- a/multitree-tasks/tca/Root.swift
+++ b/multitree-tasks/tca/Root.swift
@@ -10,30 +10,16 @@ import Foundation
 
 @Reducer
 struct Root {
-    @ObservableState
     enum ID: Hashable {
         case uuid(UUID)
         case date(Date)
-    }
-
-    @Reducer
-    struct StackDisplayFeature {
-        typealias State = ID
-
-        enum Action {
-            case addChild
-            case edit
-            case move
-            case selectChild(ID)
-            // case delete
-        }
     }
 
     @ObservableState
     struct State {
         var bag: TaskNodeBag<ID>.State = .init()
         var selectedIDs: Set<ID> = .init()
-        var path: StackState<ID> = .init()
+        var path: StackState<NodeDisplay<ID>.State> = .init()
 
         var scrollTargetColumn: ID? = .none
         var addTask: Bool = false
@@ -43,10 +29,9 @@ struct Root {
 
     enum Action: BindableAction {
         case binding(BindingAction<State>)
-        case path(StackActionOf<StackDisplayFeature>)
+        case path(StackActionOf<NodeDisplay<ID>>)
 
         case bag(TaskNodeBag<ID>.Action)
-        case itemSelected(StackElementID, _ newID: ID)
 
         case addTask(_ parent: StackElementID?)
     }
@@ -62,19 +47,14 @@ struct Root {
                 let ids = state.selectedIDs
                 state.path.removeAll()
                 if ids.count == 1 {
-                    state.path.append(ids.first!)
+                    state.path.append(.init(id: ids.first!))
                 }
-                return .none
-            case .itemSelected(let parentStackID, let id):
-                state.path.pop(to: parentStackID)
-                state.path.append(id)
-                state.scrollTargetColumn = id
                 return .none
             case .addTask(let maybeParentStackID):
                 @Dependency(\.uuid) var uuid
                 let childID: ID = .uuid(uuid())
                 let parentID: Root.ID? = switch maybeParentStackID {
-                case let .some(parentStackID): state.path[id: parentStackID]
+                case let .some(parentStackID): state.path[id: parentStackID]?.id
                 case .none: .none
                 }
                 let detail: TaskNode<ID>.Detail = .init(title: state.workingTaskTitle)
@@ -86,7 +66,7 @@ struct Root {
                 return .send(.addTask(parentStackID))
             case let .path(.element(id: parentStackID, action: .selectChild(childID))):
                 state.path.pop(to: parentStackID)
-                state.path.append(childID)
+                state.path.append(.init(id: childID))
                 state.scrollTargetColumn = childID
                 return .none
             case .bag, .binding, .path:
@@ -94,7 +74,7 @@ struct Root {
             }
         }
         .forEach(\.path, action: \.path) {
-            StackDisplayFeature()
+            NodeDisplay<ID>()
         }
     }
 }


### PR DESCRIPTION
not deadend after all, quite simple fix since we were using `StackElementID` instead of `Root.ID` for access in most places already.